### PR TITLE
Remove 404 link to helpers functions

### DIFF
--- a/docs/src/examples/simple.md
+++ b/docs/src/examples/simple.md
@@ -2,12 +2,6 @@
 
 > If a `Container` does **not** bind with [:get-child-payload](/api/callbacks.html#get-child-payload), the `element` returned inside both `@drop` and `@dropReady` come as `undefined`.
 
-::: tip Helpers
-
-You can also find the helpers functions [here](/examples/utils.html)
-
-:::
-
 <doc-example title="Simple" file="simple" />
 
 ::: details Click here to expand the code for the helpers functions


### PR DESCRIPTION
The link is 404, I'm not sure if `/examples/helpers.html` is the correct link to it.
I see helpers functions are already included at the bottom of the page, so maybe the tip can be removed?

I also checked other examples and I found only two examples have tips to link to helper functions, but not sure what to do tho
https://amendx.github.io/vue-dndrop/examples/cards.html
https://amendx.github.io/vue-dndrop/examples/cards-kanban.html