### PR TITLE
fix(core): check if event is cancelable before preventing default

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "16.x"
 
       - name: install dependencies
         run: |

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,44 @@
+name: pages
+on:
+  pull_request:
+    branches: [master]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: work around permission issue
+        run: git config --global --add safe.directory /github/workspace
+
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+
+      - name: install dependencies
+        run: |
+          npm ci
+          npm run build
+
+      - name: generate docs
+        run: |
+          cd docs/
+          npm install
+          npm run build
+
+      - name: init new repo in dist folder and commit generated files
+        run: |
+          cd docs/src/.vuepress/dist
+          git init
+          git add -A
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m 'deploy'
+
+      - name: force push to destination branch
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          force: true
+          directory: ./docs/src/.vuepress/dist

--- a/src/utils/container/mediator.js
+++ b/src/utils/container/mediator.js
@@ -355,7 +355,7 @@ function handleMouseMoveForContainer ({ clientX, clientY }, orientation = 'verti
   }
 }
 function onMouseMove (event) {
-  event.preventDefault();
+  if (event.cancelable) event.preventDefault();
   const e = getPointerEvent(event);
   if (!draggableInfo) {
     initiateDrag(e, Utils.getElementCursor(event.target));

--- a/src/utils/container/mediator.js
+++ b/src/utils/container/mediator.js
@@ -355,7 +355,7 @@ function handleMouseMoveForContainer ({ clientX, clientY }, orientation = 'verti
   }
 }
 function onMouseMove (event) {
-  if (event.cancelable) event.preventDefault();
+  event.preventDefault();
   const e = getPointerEvent(event);
   if (!draggableInfo) {
     initiateDrag(e, Utils.getElementCursor(event.target));


### PR DESCRIPTION
# Source: #79 
- [Easyfix suggested](https://www.uriports.com/blog/easy-fix-for-intervention-ignored-attempt-to-cancel-a-touchmove-event-with-cancelable-false/)
- [Docs - Mozilla](https://developer.mozilla.org/en-US/docs/Web/API/Event/cancelable)
