### PR TITLE
Remove resize listener at dispose time to avoid memory leak.

### DIFF
--- a/src/utils/container/container.js
+++ b/src/utils/container/container.js
@@ -863,6 +863,7 @@ function Container (element) {
 
     function dispose (container) {
       scrollListener.dispose();
+      container.layout.removeResizeListener();
       unwrapChildren(container.element);
     }
 

--- a/src/utils/container/layoutManager.js
+++ b/src/utils/container/layoutManager.js
@@ -191,6 +191,12 @@ export default function layoutManager (containerElement, orientation, _animation
   function setBegin (style, value) {
     propMapper.set(style, 'begin', value);
   }
+
+  function removeResizeListener() {
+    window.removeEventListener('resize', function () {
+      invalidateContainerRectangles(containerElement);
+    });
+  }
   return {
     getSize,
     getContainerRectangles,
@@ -213,5 +219,6 @@ export default function layoutManager (containerElement, orientation, _animation
     invalidateRects,
     getPosition,
     setBegin,
+    removeResizeListener,
   };
 }


### PR DESCRIPTION
Memory is leaking because resize listener has registered but never removed. 

![Screenshot 2025-03-18 at 7 45 54 PM](https://github.com/user-attachments/assets/8fc823c0-e4de-4dc0-a46e-6029b96e8208)
